### PR TITLE
En requirements elimine un paquete que da error al correr el programa

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 selenium
 webdriver-manager
-tkinter


### PR DESCRIPTION
al instalar las dependencias con el comando "pip install -r requirements.txt"

pip intenta buscar e instalar un paquete llamado tkinter en PyPI, pero no existe ningún paquete con ese nombre ahí porque tkinter forma parte de la librería estándar de Python, no es un paquete externo.